### PR TITLE
Add spec for IRI-valued annotations

### DIFF
--- a/spec/DOSDP_schema_full.yaml
+++ b/spec/DOSDP_schema_full.yaml
@@ -53,10 +53,27 @@ definitions:
          A single list variable (list_var or data_list_var).  Each item in this list 
          should be used to generate a separate annotation axiom.
         type: string
+
+  iri_value_annotation:
+    type: object
+    additionalProperties: False
+    required: [annotationProperty, var]
+    properties:
+      annotationProperty:
+        description: A string corresponding to a key in the annotation property dictionary.
+        type: string
+      var:
+        description: The name of a variable specified in the 'vars' field. The IRI of the variable value will be the object of the annotation axiom.
+        type: string
+      annotations:
+        items: { $ref: "#/definitions/annotations" } 
+        type: array
+
   annotations:
    oneOf: 
      - { $ref: "#/definitions/printf_annotation" }
      - { $ref: "#/definitions/list_annotation" }
+     - { $ref: "#/definitions/iri_value_annotation" }
 
   printf_owl:
     type: object
@@ -290,7 +307,7 @@ properties:
 # Specifying axioms:
 
   annotations:
-    items: { $ref: '#/definitions/printf_annotation'}
+    items: { $ref: "#/definitions/annotations" } 
     type: array
     
   logical_axioms:


### PR DESCRIPTION
This also changes the spec to allow any annotation type at the top level (printf annotation, list annotation, IRI value annotation)—not sure why it was limited to printf annotation before? All the `annotations` keys in nested structures allowed both types.

The purpose of this new annotation type is to be able to have an annotation axiom where the value is the IRI of an OWL entity, not a string. E.g. for https://github.com/geneontology/go-ontology/pull/16508

Parsers can distinguish this annotation type from the other kinds because it has a `var` property with a string value, rather than `vars` with a list.

@dosumis I only edited the YAML. Do you create the JSON automatically?