### PR TITLE
Added contributors field

### DIFF
--- a/spec/DOSDP_schema_full.yaml
+++ b/spec/DOSDP_schema_full.yaml
@@ -246,9 +246,10 @@ properties:
     type: array
     items: string
     description: >
-       A list of authors of a pattern. 
-       We recommend that each author is specified using an ORCID (full URL). 
-       We do not recommend that this list is instantiated in terms generated using a pattern.
+       A list of authors of a pattern.  
+       Each author must be specified using a URL or Curie - we recommend ORCID. 
+       We do not recommend that this list is instantiated in terms generated using a pattern,
+       but where it is it should be instantiated as a set of annotation axioms using dc:contributor.
 
   description:
     type: string # specify UTF-8 string?

--- a/spec/DOSDP_schema_full.yaml
+++ b/spec/DOSDP_schema_full.yaml
@@ -241,6 +241,14 @@ properties:
   base_IRI:  # not rqd, give JSON-LD base.
     type: string # how to spec IRI?
     description: "Specifies the base IRI to be used to generate new classes."
+    
+  contributors:
+    type: array
+    items: string
+    description: >
+       A list of authors of a pattern. 
+       We recommend that each author is specified using an ORCID (full URL). 
+       We do not recommend that this list is instantiated in terms generated using a pattern.
 
   description:
     type: string # specify UTF-8 string?


### PR DESCRIPTION
Fixes #44 

It might be useful to instantiate this in pattern ontologies (patterns.owl in ODK).  Given that, maybe we should recommend an official annotation property, e.g. dc:contributor?